### PR TITLE
Added static and dynamic library definitions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,14 @@ let package = Package(
         .library(
             name: "Shallows",
             targets: ["Shallows"]),
+        .library(
+            name: "ShallowsStatic",
+            type: .static,
+            targets: ["Shallows"]),
+        .library(
+            name: "ShallowsDynamic",
+            type: .dynamic,
+            targets: ["Shallows"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.


### PR DESCRIPTION
This change allows to link Shallows dynamically which makes it possible to use Shallows both in a framework as well as in the main app project simultaneously. In Xcode < 13.4 all we got was a warning at run time but in Xcode 13.4 the build process fails.